### PR TITLE
Add Support for Crunchy PostgreSQL Service, Implement Ingress Traffic Manipulation, add Rate Limiting via Netem, Option to use containerd instead of runc

### DIFF
--- a/monarch/pcf/service.py
+++ b/monarch/pcf/service.py
@@ -98,6 +98,10 @@ class Service(dict):
                     dnslookup(hostname), 'tcp',
                     credentials['amqp']['protocols']['management']['port']
                 ))
+        elif re.match("postgresql-\d+-odb", service['type']):
+            service['user'] = credentials['username']
+            service['password'] = credentials['password']
+            service['hosts'].add((credentials['db_host'], 'tcp', credentials['db_port']))
         else:
             logger.warning("Unrecognized service '%s'", service['type'])
 

--- a/monarch/pcf/util.py
+++ b/monarch/pcf/util.py
@@ -68,7 +68,13 @@ def run_cmd_on_container(dcid, contid, cmd, suppress_output=False):
     :param suppress_output: bool; If true, no extra debug output will be printed when an error occurs.
     :return: int, str, str; Returncode, stdout, stderr.
     """
-    shell_cmd = 'exec sudo /var/vcap/packages/runc/bin/runc exec -t {} /bin/bash'.format(contid)
+    cfg = Config()
+    use_containerd = cfg.get("use-containerd") is not None
+    if use_containerd:
+        # Refer to: https://devops.stackexchange.com/a/13781/27344
+        shell_cmd = f'exec sudo /var/vcap/packages/containerd/bin/ctr -a /var/vcap/sys/run/containerd/containerd.sock -n garden tasks exec --exec-id my-shell --tty {contid} /bin/bash'
+    else:
+        shell_cmd = f'exec sudo /var/vcap/packages/runc/bin/runc exec -t {contid} /bin/bash'
     if isinstance(cmd, list):
         cmd.insert(0, shell_cmd)
     else:


### PR DESCRIPTION
[Crunchy PostgreSQL Service](https://access.crunchydata.com/documentation/pcf/latest/using-crunchy-postgresql-for-pcf/) has services that follow the pattern of `postgresql-11-odb`.  Seems like a reasonable assumption that the needed values in the services yaml will be the same across the versions, so chose to cover all `postgresql-\d+-odb` with a single pattern.

The approach for implementing ingress traffic manipulation was almost entirely copied from here:
https://wiki.linuxfoundation.org/networking/netem#how_can_i_use_netem_on_incoming_traffic

The only notes with that are:
- One of the setup commands is `sudo modprobe ifb` ... leaving this module loaded seems relatively harmless compared to unloading it in the case that we were not the ones who loaded it (as in, someone/thing else is depending on it being loaded) so I opted to leave it loaded rather than try to undo that during the `unmanipulate_traffic` method.
- Same deal as the above when it comes to the `ifb0` interface being up. harmless to leave up, but harmful to take down if someone else is depending on it.
  - TBH, I am open to disagreement on these two points though.

Finally, I also added rate limiting via netem to the `manipulate_traffic` method. This should be nice since it says that the shape traffic can not happen at the same time as `manipulate_traffic` but this will allow the insertion of throughput limiting alongside other traffic manipulations like latency, loss, etc. 

Based on the PCF release notes here: https://docs.pivotal.io/pivotalcf/2-6/pcf-release-notes/runtime-rn.html ... in newer releases, `containerd` is used instead of `runc`. I added the ability to use `containerd` to get a shell / execute commands on a container which can be enabled via a `use-containerd` entry in the config. this is disabled by default so will not effect behavior unless you choose to.